### PR TITLE
Host DocC documentation in the Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 1
+builder:
+  configs:
+    - documentation_targets: [PIRService, PrivacyPass]


### PR DESCRIPTION
[Documentation](https://swiftpackageindex.com/swiftpackageindex/spimanifest/1.5.1/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index) of the `.spi.yml` file.