### PR TITLE
Bump swift-homomorphic-encryption version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b2168a912748ab1b1f3ac0726ec1bb7c049f1dc1089c8ccd5e5d0dda1d44c42",
+  "originHash" : "539e5b945ef0e600bf17ba3f7064309942887ab46e8df9dfeec298679c358203",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -114,7 +114,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-homomorphic-encryption",
       "state" : {
-        "revision" : "578a38e1f7b2e4a4da26b93060ae31b89a4ea5e7"
+        "revision" : "a5691b2b1b5ed0d59d45828143361de648b96572"
       }
     },
     {
@@ -192,7 +192,7 @@
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
         "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
         "version" : "1.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
         .package(
             url: "https://github.com/apple/swift-homomorphic-encryption",
-            revision: "578a38e1f7b2e4a4da26b93060ae31b89a4ea5e7"),
+            revision: "a5691b2b1b5ed0d59d45828143361de648b96572"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.27.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.0.0-rc.2"),
     ],


### PR DESCRIPTION
Bump swift-homomophic-encryption version to get https://github.com/apple/swift-homomorphic-encryption/pull/9; this should fix swift package index [build failures](https://swiftpackageindex.com/builds/4CB3529D-1C52-4BC2-8579-AE4F1F0F4782):
```
    fatal: clone of 'git@github.com:apple/swift-homomorphic-encryption-protobuf.git' into submodule path '/host/spi-builder-workspace/.build/checkouts/swift-homomorphic-encryption/swift-homomorphic-encryption-protobuf' failed
```