### PR TITLE
Remove @retroactive

### DIFF
--- a/Sources/PIRService/Extensions/HEError+HTTPErrorResponse.swift
+++ b/Sources/PIRService/Extensions/HEError+HTTPErrorResponse.swift
@@ -16,7 +16,7 @@ import HomomorphicEncryption
 import Hummingbird
 import PrivateInformationRetrieval
 
-extension HomomorphicEncryption.HeError: @retroactive HTTPResponseError {
+extension HomomorphicEncryption.HeError: Hummingbird.HTTPResponseError {
     public var status: HTTPResponse.Status {
         .badRequest
     }
@@ -27,7 +27,7 @@ extension HomomorphicEncryption.HeError: @retroactive HTTPResponseError {
     }
 }
 
-extension PrivateInformationRetrieval.PirError: @retroactive HTTPResponseError {
+extension PrivateInformationRetrieval.PirError: Hummingbird.HTTPResponseError {
     public var status: HTTPResponse.Status {
         .badRequest
     }

--- a/Sources/PIRService/Extensions/PrivacyPass+ResponseGenerator.swift
+++ b/Sources/PIRService/Extensions/PrivacyPass+ResponseGenerator.swift
@@ -15,7 +15,7 @@
 import Hummingbird
 import PrivacyPass
 
-extension PrivacyPass.PrivacyPassError: @retroactive HTTPResponseError {
+extension PrivacyPass.PrivacyPassError: Hummingbird.HTTPResponseError {
     public var status: HTTPTypes.HTTPResponse.Status {
         // Default to `.badRequest` however, some erros types are specified to return HTTP 422.
         // From: https://www.rfc-editor.org/rfc/rfc9578#name-issuer-to-client-response-2
@@ -39,13 +39,13 @@ extension PrivacyPass.PrivacyPassError: @retroactive HTTPResponseError {
     }
 }
 
-extension TokenIssuerDirectory: @retroactive ResponseGenerator {
+extension TokenIssuerDirectory: Hummingbird.ResponseGenerator {
     public func response(from request: HummingbirdCore.Request, context: some RequestContext) throws -> Response {
         try context.responseEncoder.encode(self, from: request, context: context)
     }
 }
 
-extension PrivacyPass.TokenResponse: @retroactive ResponseGenerator {
+extension PrivacyPass.TokenResponse: Hummingbird.ResponseGenerator {
     public func response(from _: HummingbirdCore.Request, context: some RequestContext) throws -> Response {
         let body = context.allocator.buffer(bytes: bytes())
         return Response(
@@ -55,7 +55,7 @@ extension PrivacyPass.TokenResponse: @retroactive ResponseGenerator {
     }
 }
 
-extension PrivacyPass.PublicKey: @retroactive ResponseGenerator {
+extension PrivacyPass.PublicKey: Hummingbird.ResponseGenerator {
     public func response(from _: Request, context: some RequestContext) throws -> Response {
         let body = try context.allocator.buffer(bytes: spki())
         return Response(status: .ok, body: .init(byteBuffer: body))

--- a/Sources/PIRService/server.swift
+++ b/Sources/PIRService/server.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArgumentParser
-import Foundation
+@preconcurrency import Foundation
 import Hummingbird
 
 struct ServerConfiguration: Codable {


### PR DESCRIPTION
Swift 5.10 compiler does not know about `@retroactive` attribute.