### PR TITLE
Add response compression for Config fetch endpoint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e543317e5aefdb9f50f59e851b877b3b6af8997034a5657f791c7a60febb9ce",
+  "originHash" : "a8283d84c07f02390e501e27aead610f1420e15e5b665c7ce15f0c17496a23d5",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -11,12 +11,30 @@
       }
     },
     {
+      "identity" : "compress-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/compress-nio.git",
+      "state" : {
+        "revision" : "a52d3ac5f48820846d34d78d6f59316481e84968",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "hummingbird",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird",
       "state" : {
         "revision" : "d4f792d209f02b26a17c0105751220da65207fb2",
         "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "hummingbird-compression",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird-compression",
+      "state" : {
+        "revision" : "78cb36ee8ebbb4a95c56979a98d6161b9890a970",
+        "version" : "2.0.0-rc.2"
       }
     },
     {
@@ -114,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-homomorphic-encryption",
       "state" : {
-        "revision" : "cf5a7d70169b44ecaafc8f645653f6873d9ae5ba",
-        "version" : "1.0.0"
+        "revision" : "1d7e43a45123ce3190b0545fad05bde25d28980c",
+        "version" : "1.0.1"
       }
     },
     {
@@ -193,7 +211,7 @@
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
+      "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
         "version" : "1.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-homomorphic-encryption", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.27.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-compression", from: "2.0.0-rc.2"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -46,6 +47,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "HomomorphicEncryptionProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdCompression", package: "hummingbird-compression"),
                 .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "SwiftASN1", package: "swift-asn1"),
             ],

--- a/Sources/PIRService/Controllers/PIRServiceController.swift
+++ b/Sources/PIRService/Controllers/PIRServiceController.swift
@@ -15,6 +15,7 @@
 import Foundation
 import HomomorphicEncryptionProtobuf
 import Hummingbird
+import HummingbirdCompression
 import PrivateInformationRetrievalProtobuf
 
 struct PIRServiceController {
@@ -28,8 +29,9 @@ struct PIRServiceController {
     func addRoutes(to group: RouterGroup<AppContext>) {
         group.add(middleware: ExtractUserIdentifierMiddleware())
             .post("/key", use: key)
-            .post("/config", use: config)
             .post("/queries", use: queries)
+            .add(middleware: ResponseCompressionMiddleware())
+            .post("/config", use: config)
     }
 
     @Sendable

--- a/Tests/PIRServiceTests/TestClientProtocol+Protobuf.swift
+++ b/Tests/PIRServiceTests/TestClientProtocol+Protobuf.swift
@@ -23,10 +23,14 @@ public extension TestClientProtocol {
         uri: String,
         userIdentifier: UserIdentifier,
         message: some Message,
+        acceptCompression: Bool = false,
         testCallback: @escaping (TestResponse) async throws -> Return = { $0 }) async throws -> Return
     {
         let bodyBuffer = try ByteBuffer(data: message.serializedData())
-        let headers: HTTPFields = [.userIdentifier: userIdentifier.identifier]
+        var headers: HTTPFields = [.userIdentifier: userIdentifier.identifier]
+        if acceptCompression {
+            headers[.acceptEncoding] = "gzip"
+        }
         let response = try await executeRequest(uri: uri, method: .post, headers: headers, body: bodyBuffer)
         return try await testCallback(response)
     }


### PR DESCRIPTION
Only the config fetch should use Response compression.
Other endpoints (key upload & query) handle ciphertexts that are hard to compress.