### PR TITLE
Remove issuerRequestUri from configuration

### DIFF
--- a/Sources/PIRService/Controllers/PrivacyPassController.swift
+++ b/Sources/PIRService/Controllers/PrivacyPassController.swift
@@ -48,10 +48,12 @@ struct PrivacyPassController<UserAuthenticator: UserTokenAuthenticator> {
                 tokenKeyBase64Url: spki.base64URLEncodedString(),
                 notBefore: nil)
         }
+        // swiftlint:disable:next force_unwrapping
+        let issuerRequestUri = URL(string: "/issue")!
         #if canImport(Darwin)
-        return TokenIssuerDirectory(issuerRequestUri: state.issuerRequestUri, tokenKeys: tokenKeys)
+        return TokenIssuerDirectory(issuerRequestUri: issuerRequestUri, tokenKeys: tokenKeys)
         #else
-        return await TokenIssuerDirectory(issuerRequestUri: state.issuerRequestUri, tokenKeys: tokenKeys)
+        return await TokenIssuerDirectory(issuerRequestUri: issuerRequestUri, tokenKeys: tokenKeys)
         #endif
     }
 

--- a/Sources/PIRService/Controllers/PrivacyPassState.swift
+++ b/Sources/PIRService/Controllers/PrivacyPassState.swift
@@ -25,14 +25,13 @@ actor PrivacyPassState<UserAuthenticator: UserTokenAuthenticator> {
         let tier: UserTier
     }
 
-    let issuerRequestUri: URL
     let userAuthenticator: UserAuthenticator
     // map from tier to issuer
     var issuers: [UserTier: PrivacyPass.Issuer]
     // map from truncate key id to verifier & tier
     var verifiers: [UInt8: TieredVerifier]
 
-    init(issuerRequestUri: URL, userAuthenticator: UserAuthenticator) throws {
+    init(userAuthenticator: UserAuthenticator) throws {
         var issuers: [UserTier: PrivacyPass.Issuer] = [:]
         var verifiers: [UInt8: TieredVerifier] = [:]
         // generate issuers for each user tier and avoid truncated key id collisions
@@ -47,7 +46,6 @@ actor PrivacyPassState<UserAuthenticator: UserTokenAuthenticator> {
                 tier: tier)
         }
 
-        self.issuerRequestUri = issuerRequestUri
         self.userAuthenticator = userAuthenticator
         self.issuers = issuers
         self.verifiers = verifiers

--- a/Sources/PIRService/PIRService.docc/TestingInstructions.md
+++ b/Sources/PIRService/PIRService.docc/TestingInstructions.md
@@ -204,7 +204,6 @@ Copy the following to a file called `service-config.json`.
 
 ```json
 {
-  "issuerRequestUri": "http://lookup.example.net/issue",
   "users": [
     {
       "tier1": {}
@@ -237,14 +236,9 @@ Copy the following to a file called `service-config.json`.
 
 This configuration file has 3 sections.
 
-1. `issuerRequestUri` - This URL will be included in the Privacy Pass token issuer directory. It needs to end with
-   `/issue` and point to the address of your service. In this example we assume that the service will be reachable at
-   `http://lookup.example.net`.
-> Note: This value can be omitted from the configuration. Setting this explicitly will not be required for devices using
-> iOS 18.0 beta 4 or later.
-2. `users` - This is a mapping from user tiers to User Tokens that are allowed for that tier. The User tokens are
+1. `users` - This is a mapping from user tiers to User Tokens that are allowed for that tier. The User tokens are
    already base64 encoded as they appear in the HTTP `Authorization` header.
-3. `usecases` - This is a list of usecases, where each usecase has the `fileStem`, `shardCount`, and `name`. When
+2. `usecases` - This is a list of usecases, where each usecase has the `fileStem`, `shardCount`, and `name`. When
    loading the usecase, `PIRService` does something like:
 ```swift
 self.shards = try (0..<shardCount).map { shardIndex in
@@ -304,5 +298,3 @@ the device find your Mac. Let's assume that your Mac's hostname is `Tims-MacBook
 
 Then we should use the following value for the URLs: `http://Tims-Macbook-Pro.local:8080`. Thanks to the mDNS protocol
 your device should be able to resolve your hostname to the actual IP address of your Mac and make the connection.
-
-> Tip: Do not forget to also update the `issuerRequestUri` field in the service configuration.

--- a/Sources/PIRService/server.swift
+++ b/Sources/PIRService/server.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArgumentParser
-@preconcurrency import Foundation
+import Foundation
 import Hummingbird
 
 struct ServerConfiguration: Codable {
@@ -23,7 +23,6 @@ struct ServerConfiguration: Codable {
         let shardCount: Int
     }
 
-    let issuerRequestUri: String?
     let users: [UserTier: [String]]
     let usecases: [Usecase]
 }
@@ -52,18 +51,7 @@ struct ServerCommand: AsyncParsableCommand {
                     await authenticator.add(token: user, tier: tier)
                 }
             }
-
-            var issuerRequestUri: URL
-            if let issuerRequestUriString = config.issuerRequestUri {
-                guard let parsed = URL(string: issuerRequestUriString) else {
-                    throw ValidationError("invalid issuerRequestUri: \(issuerRequestUriString)")
-                }
-                issuerRequestUri = parsed
-            } else {
-                // swiftlint:disable:next force_unwrapping
-                issuerRequestUri = URL(string: "/issue")!
-            }
-            privacyPassState = try .init(issuerRequestUri: issuerRequestUri, userAuthenticator: authenticator)
+            privacyPassState = try .init(userAuthenticator: authenticator)
         }
 
         for usecase in config.usecases {


### PR DESCRIPTION
Hopefully now there are no more users on iOS 18 early betas, that needed the full URL in the token issuer directory configuration.