### PR TITLE
Make PrivacyPassError a struct for better backwards-compatibility.

### DIFF
--- a/Sources/PIRService/Controllers/PrivacyPassController.swift
+++ b/Sources/PIRService/Controllers/PrivacyPassController.swift
@@ -73,7 +73,7 @@ struct PrivacyPassController<UserAuthenticator: UserTokenAuthenticator> {
         var tokenRequestByteBuffer = try await request.body.collect(upTo: PrivacyPass.TokenRequest.sizeInBytes)
         guard let tokenRequestBytes = tokenRequestByteBuffer.readBytes(length: PrivacyPass.TokenRequest.sizeInBytes)
         else {
-            throw PrivacyPass.PrivacyPassError.invalidTokenRequestSize
+            throw PrivacyPass.PrivacyPassError(code: .invalidTokenRequestSize)
         }
         let tokenRequest = try PrivacyPass.TokenRequest(from: tokenRequestBytes)
 

--- a/Sources/PIRService/Extensions/PrivacyPass+ResponseGenerator.swift
+++ b/Sources/PIRService/Extensions/PrivacyPass+ResponseGenerator.swift
@@ -21,7 +21,7 @@ extension PrivacyPass.PrivacyPassError: Hummingbird.HTTPResponseError {
         // From: https://www.rfc-editor.org/rfc/rfc9578#name-issuer-to-client-response-2
         // If any of these conditions are not met, the Issuer MUST return an HTTP 422 (Unprocessable Content) error to
         // the Client.
-        switch self {
+        switch code {
         case .invalidTokenKeyId:
             .unprocessableContent
         case .invalidTokenRequestBlindedMessageSize:

--- a/Sources/PrivacyPass/Issuer.swift
+++ b/Sources/PrivacyPass/Issuer.swift
@@ -30,7 +30,7 @@ public struct Issuer: Sendable {
     /// - Parameter privateKey: Private key to use for issuing tokens.
     public init(privateKey: PrivateKey) throws {
         guard privateKey.backing.keySizeInBits == TokenTypeBlindRSAKeySizeInBits else {
-            throw PrivacyPassError.invalidKeySize
+            throw PrivacyPassError(code: .invalidKeySize)
         }
         self.privateKey = privateKey
         self.truncatedTokenKeyId = privateKey.publicKey.truncatedTokenKeyId
@@ -49,13 +49,13 @@ public struct Issuer: Sendable {
     /// Response](https://www.rfc-editor.org/rfc/rfc9578#name-issuer-to-client-response-2)
     public func issue(request: TokenRequest) throws -> TokenResponse {
         guard request.tokenType == TokenTypeBlindRSA else {
-            throw PrivacyPassError.invalidTokenType
+            throw PrivacyPassError(code: .invalidTokenType)
         }
         guard request.truncatedTokenKeyId == truncatedTokenKeyId else {
-            throw PrivacyPassError.invalidTokenKeyId
+            throw PrivacyPassError(code: .invalidTokenKeyId)
         }
         guard request.blindedMsg.count == TokenTypeBlindRSANK else {
-            throw PrivacyPassError.invalidTokenRequestBlindedMessageSize
+            throw PrivacyPassError(code: .invalidTokenRequestBlindedMessageSize)
         }
 
         let signature = try privateKey.backing.blindSignature(for: request.blindedMsg)

--- a/Sources/PrivacyPass/PrivacyPassError.swift
+++ b/Sources/PrivacyPass/PrivacyPassError.swift
@@ -13,13 +13,174 @@
 // limitations under the License.
 
 /// Privacy Pass error.
-public enum PrivacyPassError: Error, Equatable, Sendable {
-    case invalidKeySize
-    case invalidSPKIFormat
-    case invalidTokenKeyId
-    case invalidTokenRequestBlindedMessageSize
-    case invalidTokenRequestSize
-    case invalidTokenResponseSize
-    case invalidTokenSize
-    case invalidTokenType
+public struct PrivacyPassError: Error, Equatable, Sendable {
+    /// A high-level error code to provide a broad classification.
+    public var code: Code
+
+    /// The location from which this error was thrown.
+    public var location: SourceLocation
+
+    /// Creates a new ``PrivacyPassError``.
+    /// - Parameters:
+    ///   - code: Error code.
+    ///   - location: Source location where the error occured.
+    @inlinable
+    public init(code: Code, location: SourceLocation) {
+        self.code = code
+        self.location = location
+    }
+
+    /// Creates a new ``PrivacyPassError``.
+    /// - Parameters:
+    ///   - code: Error code.
+    ///   - function: The function in which the error was thrown.
+    ///   - file: The file in which the error was thrown.
+    ///   - line: The line on which the error was thrown.
+    @inlinable
+    public init(
+        code: Code,
+        function: String = #function,
+        file: String = #fileID,
+        line: Int = #line)
+    {
+        self.code = code
+        self.location = SourceLocation(function: function, file: file, line: line)
+    }
+}
+
+extension PrivacyPassError: CustomStringConvertible {
+    public var description: String {
+        "\(code)"
+    }
+}
+
+extension PrivacyPassError: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "\(code): \(location.description)"
+    }
+}
+
+public extension PrivacyPassError {
+    /// A high level indication of the kind of error being thrown.
+    struct Code: Hashable, Sendable, CustomStringConvertible {
+        // Adding cases to an enum is source-breaking (since adopters might switch on an enum value without a default).
+        // So we keep the enum private.
+        private enum InternalCode: Hashable, Sendable, CustomStringConvertible { // swiftlint:disable:this nesting
+            case invalidKeySize
+            case invalidSPKIFormat
+            case invalidTokenKeyId
+            case invalidTokenRequestBlindedMessageSize
+            case invalidTokenRequestSize
+            case invalidTokenResponseSize
+            case invalidTokenSize
+            case invalidTokenType
+
+            var description: String {
+                switch self {
+                case .invalidKeySize:
+                    "Invalid key size"
+                case .invalidSPKIFormat:
+                    "Invalid SPKI Format"
+                case .invalidTokenKeyId:
+                    "Invalid Token Id"
+                case .invalidTokenRequestBlindedMessageSize:
+                    "Invalid token request blinded message size"
+                case .invalidTokenRequestSize:
+                    "Invalid token request size"
+                case .invalidTokenResponseSize:
+                    "Invalid token response size"
+                case .invalidTokenSize:
+                    "Invalid token size"
+                case .invalidTokenType:
+                    "Invalid token type"
+                }
+            }
+        }
+
+        public var description: String {
+            String(describing: code)
+        }
+
+        private var code: InternalCode
+
+        private init(_ code: InternalCode) {
+            self.code = code
+        }
+
+        /// Invalid key size.
+        public static var invalidKeySize: Self {
+            Self(.invalidKeySize)
+        }
+
+        /// Invalid SPKI format.
+        public static var invalidSPKIFormat: Self {
+            Self(.invalidSPKIFormat)
+        }
+
+        /// Invalid token identifier.
+        public static var invalidTokenKeyId: Self {
+            Self(.invalidTokenKeyId)
+        }
+
+        /// Invalid blinded message size in the token request.
+        public static var invalidTokenRequestBlindedMessageSize: Self {
+            Self(.invalidTokenRequestBlindedMessageSize)
+        }
+
+        /// Invalid token request size.
+        public static var invalidTokenRequestSize: Self {
+            Self(.invalidTokenRequestSize)
+        }
+
+        /// Invalid token response size.
+        public static var invalidTokenResponseSize: Self {
+            Self(.invalidTokenResponseSize)
+        }
+
+        /// Invalid token size.
+        public static var invalidTokenSize: Self {
+            Self(.invalidTokenSize)
+        }
+
+        /// Invalid token type.
+        public static var invalidTokenType: Self {
+            Self(.invalidTokenType)
+        }
+    }
+
+    /// A location within source code.
+    struct SourceLocation: Sendable, Hashable, CustomStringConvertible {
+        /// The function in which the error was thrown.
+        public let function: String
+
+        /// The file in which the error was thrown.
+        public let file: String
+
+        /// The line on which the error was thrown.
+        public let line: Int
+
+        public var description: String {
+            "in \(function) at \(file):\(line)"
+        }
+
+        /// Creates a new ``SourceLocation``
+        /// - Parameters:
+        ///   - function: The function in which the error was thrown.
+        ///   - file: The file in which the error was thrown.
+        ///   - line: The line on which the error was thrown.
+        public init(function: String, file: String, line: Int) {
+            self.function = function
+            self.file = file
+            self.line = line
+        }
+
+        /// A ``SourceLocation`` which is the current location.
+        /// - Parameters:
+        ///   - function: The function in which the error was thrown.
+        ///   - file: The file in which the error was thrown.
+        ///   - line: The line on which the error was thrown.
+        public static func here(function: String = #function, file: String = #fileID, line: Int = #line) -> Self {
+            SourceLocation(function: function, file: file, line: line)
+        }
+    }
 }

--- a/Sources/PrivacyPass/PublicKey.swift
+++ b/Sources/PrivacyPass/PublicKey.swift
@@ -65,7 +65,7 @@ public struct PublicKey: Sendable {
               let rsassaPSSParams = try? RSASSAPSSParams(asn1Any: parameters),
               rsassaPSSParams == Self.rsassaPSSParams
         else {
-            throw PrivacyPassError.invalidSPKIFormat
+            throw PrivacyPassError(code: .invalidSPKIFormat)
         }
 
         // overwrite algorithmIdentifier such the Crypto can recognize the format

--- a/Sources/PrivacyPass/Token.swift
+++ b/Sources/PrivacyPass/Token.swift
@@ -71,7 +71,7 @@ public struct Token: Equatable {
     /// - Parameter bytes: Collection of bytes representing a token.
     public init<C: Collection<UInt8>>(from bytes: C) throws {
         guard bytes.count == Self.sizeInBytes else {
-            throw PrivacyPassError.invalidTokenSize
+            throw PrivacyPassError(code: .invalidTokenSize)
         }
         var offset = bytes.startIndex
 

--- a/Sources/PrivacyPass/TokenRequest.swift
+++ b/Sources/PrivacyPass/TokenRequest.swift
@@ -50,7 +50,7 @@ public struct TokenRequest: Equatable {
     /// - Parameter bytes: Collection of bytes representing a token request.
     public init<C: Collection<UInt8>>(from bytes: C) throws {
         guard bytes.count == Self.sizeInBytes else {
-            throw PrivacyPassError.invalidTokenRequestSize
+            throw PrivacyPassError(code: .invalidTokenRequestSize)
         }
         var offset = bytes.startIndex
 

--- a/Sources/PrivacyPass/TokenResponse.swift
+++ b/Sources/PrivacyPass/TokenResponse.swift
@@ -36,7 +36,7 @@ public struct TokenResponse: Equatable {
     /// - Parameter bytes: Collection of bytes representing a token reponse.
     public init(from bytes: some Collection<UInt8>) throws {
         guard bytes.count == Self.sizeInBytes else {
-            throw PrivacyPassError.invalidTokenResponseSize
+            throw PrivacyPassError(code: .invalidTokenResponseSize)
         }
         self.blindSignature = Array(bytes)
     }


### PR DESCRIPTION
Adding a case to a public enum is a source-breaking change.
To avoid this, (especially since we aren't yet at 1.0.0), we refactor the error type to hide the underlying enum.