### PR TITLE
Reload configuration & usecases on SIGHUP

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0f6313dce696999312478d28b401a6688986a9f24af45143c83d80689a7952b9",
+  "originHash" : "97a08d4d803da699de28745e0142f5cc056c0fa9ab12ebc221c9625c2c54ff77",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.27.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-compression", from: "2.0.0-rc.2"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -53,6 +54,8 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdCompression", package: "hummingbird-compression"),
                 .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+                .product(name: "UnixSignals", package: "swift-service-lifecycle"),
             ],
             swiftSettings: swiftSettings),
         .testTarget(

--- a/Sources/PIRService/Application+build.swift
+++ b/Sources/PIRService/Application+build.swift
@@ -53,6 +53,7 @@ func buildApplication(
 {
     let router = Router(context: AppContext.self)
     router.middlewares.add(LogRequestsMiddleware(.info, includeHeaders: .none))
+    router.middlewares.add(LogErrorsMiddleware())
 
     let pirServiceController = PIRServiceController(usecases: usecaseStore, evaluationKeyStore: evaluationKeyStore)
     let pirGroup = router.group()

--- a/Sources/PIRService/Controllers/PirUsecase.swift
+++ b/Sources/PIRService/Controllers/PirUsecase.swift
@@ -104,7 +104,10 @@ struct PirUsecase<PirScheme: IndexPirServer>: Usecase {
         pirConfig.algorithm = .mulPir
         pirConfig.batchSize = UInt64(shards.first?.indexPirParameter.batchSize ?? 1)
         pirConfig.evaluationKeyConfigHash = try evaluationKeyConfig().sha256()
-        return Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { $0.pirConfig = pirConfig }
+        return try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { config in
+            config.pirConfig = pirConfig
+            config.configID = try pirConfig.sha256()
+        }
     }
 
     func evaluationKeyConfig() throws -> Apple_SwiftHomomorphicEncryption_V1_EvaluationKeyConfig {

--- a/Sources/PIRService/Controllers/UsecaseStore.swift
+++ b/Sources/PIRService/Controllers/UsecaseStore.swift
@@ -16,7 +16,60 @@ import HomomorphicEncryption
 import PrivateInformationRetrieval
 
 actor UsecaseStore {
-    var store: [String: Usecase]
+    typealias ConfigId = [UInt8]
+
+    struct VersionedUsecases {
+        /// Newest configuration ID.
+        var latestConfigId: ConfigId? {
+            configIds.last
+        }
+
+        /// Mapping from Configuration ID to usecase.
+        var usecases: [ConfigId: Usecase]
+        /// Configuration IDs, in order from oldest to newest.
+        var configIds: [ConfigId]
+        /// How many versions to store.
+        var versionCount: Int
+
+        init(versionCount: Int) {
+            self.usecases = [:]
+            self.configIds = []
+            self.versionCount = versionCount
+        }
+
+        mutating func add(usecase: Usecase, versionCount: Int? = nil) throws {
+            let configId = try Array(usecase.config().configID)
+            // make sure there are no double entries with the same configID.
+            if let existingLocation = configIds.firstIndex(of: configId) {
+                configIds.remove(at: existingLocation)
+            }
+            configIds.append(configId)
+            usecases[configId] = usecase
+
+            if let versionCount {
+                self.versionCount = versionCount
+            }
+            trim()
+        }
+
+        /// Remove old usecases
+        mutating func trim() {
+            precondition(versionCount >= 0)
+            while configIds.count > versionCount {
+                let removedConfigID = configIds.removeFirst()
+                usecases[removedConfigID] = nil
+            }
+        }
+
+        var usecase: Usecase? {
+            if let latestConfigId {
+                return usecases[latestConfigId]
+            }
+            return nil
+        }
+    }
+
+    var store: [String: VersionedUsecases]
 
     var allUsecaseNames: [String] {
         .init(store.keys)
@@ -26,20 +79,36 @@ actor UsecaseStore {
         self.store = [:]
     }
 
-    func set(name: String, usecase: Usecase?) {
-        store[name] = usecase
+    func set(name: String, usecase: Usecase?, versionCount: Int = 2) throws {
+        if let usecase {
+            try store[name, default: .init(versionCount: versionCount)].add(
+                usecase: usecase,
+                versionCount: versionCount)
+        } else {
+            store[name] = nil
+        }
+    }
+
+    func get(name: String, configId: ConfigId) -> Usecase? {
+        store[name]?.usecases[configId]
     }
 
     func get(name: String) -> Usecase? {
-        store[name]
+        store[name]?.usecase
     }
 
     func get(names: [String]) -> [String: Usecase] {
         .init(uniqueKeysWithValues: names.compactMap { name in
-            guard let usecase = store[name] else {
+            guard let usecase = store[name]?.usecase else {
                 return nil
             }
             return (name, usecase)
         })
+    }
+
+    func getAll() -> [String: Usecase] {
+        store.compactMapValues { versionedUsecases in
+            versionedUsecases.usecase
+        }
     }
 }

--- a/Sources/PIRService/ReloadService.swift
+++ b/Sources/PIRService/ReloadService.swift
@@ -1,0 +1,101 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Logging
+import ServiceLifecycle
+import UnixSignals
+
+struct ServerConfiguration: Codable {
+    struct Usecase: Codable {
+        let name: String
+        let fileStem: String
+        let shardCount: Int
+        let versionCount: Int?
+    }
+
+    let issuerRequestUri: String?
+    let users: [UserTier: [String]]
+    let usecases: [Usecase]
+}
+
+actor ReloadService: Service {
+    let configFile: URL
+    let usecaseStore: UsecaseStore
+    let privacyPassState: PrivacyPassState<UserAuthenticator>
+    let logger: Logger
+
+    init(
+        configFile: URL,
+        usecaseStore: UsecaseStore,
+        privacyPassState: PrivacyPassState<UserAuthenticator>,
+        logger: Logger)
+    {
+        self.configFile = configFile
+        self.usecaseStore = usecaseStore
+        self.privacyPassState = privacyPassState
+        self.logger = logger
+    }
+
+    func run() async throws {
+        let signalSequence = await UnixSignalsSequence(trapping: .sighup)
+        for await signal in signalSequence {
+            guard signal == .sighup else {
+                continue
+            }
+
+            logger.info("Reloading configuration...")
+            do {
+                try await reloadConfiguration()
+                logger.info("Reloading configuration completed.")
+            } catch {
+                logger.error("Failed to reload configuration: \(error.localizedDescription).")
+                logger.error("Service state might have been partially updated.")
+            }
+        }
+    }
+
+    func reloadConfiguration() async throws {
+        let configData = try Data(contentsOf: configFile)
+        let config = try JSONDecoder().decode(ServerConfiguration.self, from: configData)
+
+        var allowedUsers: [String: UserTier] = [:]
+        for (tier, users) in config.users {
+            for user in users {
+                if let existingTier = allowedUsers[user],
+                   existingTier != tier
+                {
+                    logger.warning("""
+                        User token '\(user)' is assigned to multiple tiers '\(existingTier)' \
+                        and '\(tier)', using the latter.
+                        """)
+                }
+                allowedUsers[user] = tier
+            }
+        }
+        await privacyPassState.userAuthenticator.update(allowList: allowedUsers)
+
+        for usecase in config.usecases {
+            // default to two versions
+            let versionCount = usecase.versionCount ?? 2
+            if versionCount == 0 {
+                // special case, remove all versions
+                try await usecaseStore.set(name: usecase.name, usecase: nil, versionCount: versionCount)
+                return
+            }
+            let loaded = try loadUsecase(from: usecase.fileStem, shardCount: usecase.shardCount)
+            try await usecaseStore.set(name: usecase.name, usecase: loaded, versionCount: versionCount)
+        }
+    }
+}

--- a/Tests/PIRServiceTests/ExampleUsecase.swift
+++ b/Tests/PIRServiceTests/ExampleUsecase.swift
@@ -17,13 +17,17 @@ import HomomorphicEncryption
 import PrivateInformationRetrieval
 
 enum ExampleUsecase {
+    /// Usecase where there are keys in the range `0..<10` and the values are equal to keys.
+    static let ten: Usecase = // swiftlint:disable:next force_try
+        try! buildExampleUsecase(count: 10)
+
     /// Usecase where there are keys in the range `0..<100` and the values are equal to keys.
     static let hundred: Usecase = // swiftlint:disable:next force_try
-        try! buildExampleUsecase()
+        try! buildExampleUsecase(count: 100)
 
-    private static func buildExampleUsecase() throws -> Usecase {
+    private static func buildExampleUsecase(count: Int) throws -> Usecase {
         typealias ServerType = KeywordPirServer<MulPirServer<Bfv<UInt32>>>
-        let databaseRows = (0..<100)
+        let databaseRows = (0..<count)
             .map { KeywordValuePair(keyword: [UInt8](String($0).utf8), value: [UInt8](String($0).utf8)) }
         let context: Context<ServerType.Scheme> =
             try .init(encryptionParameters: .init(from: .n_4096_logq_27_28_28_logt_4))

--- a/Tests/PIRServiceTests/PIRServiceControllerTests.swift
+++ b/Tests/PIRServiceTests/PIRServiceControllerTests.swift
@@ -76,7 +76,7 @@ class PIRServiceControllerTests: XCTestCase {
     func testConfigFetch() async throws {
         let usecaseStore = UsecaseStore()
         let exampleUsecase = ExampleUsecase.hundred
-        await usecaseStore.set(name: "test", usecase: exampleUsecase)
+        try await usecaseStore.set(name: "test", usecase: exampleUsecase)
         let app = try await buildApplication(usecaseStore: usecaseStore)
         let user = UserIdentifier()
 
@@ -134,7 +134,7 @@ class PIRServiceControllerTests: XCTestCase {
 
         let usecaseStore = UsecaseStore()
         let exampleUsecase = TestUseCaseWithLargeConfig()
-        await usecaseStore.set(name: "test", usecase: exampleUsecase)
+        try await usecaseStore.set(name: "test", usecase: exampleUsecase)
 
         let app = try await buildApplication(usecaseStore: usecaseStore)
         let user = UserIdentifier()


### PR DESCRIPTION
This implements two things:
* Supporting multiple versions of a dataset & routing to the right dataset based on configuration identifier.
* Reloading of the configuration when SIGHUP signal is sent to the process.