### PR TITLE
Add Fixed PIR Shard Config

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .executableTarget(
             name: "PIRService",
             dependencies: [
-                "PrivacyPass",
+                "PrivacyPass", "Util",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "HomomorphicEncryptionProtobuf", package: "swift-homomorphic-encryption"),
@@ -78,11 +78,13 @@ let package = Package(
         .target(
             name: "PrivacyPass",
             dependencies: [
+                "Util",
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "SwiftASN1", package: "swift-asn1"),
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
             ],
             swiftSettings: swiftSettings),
+        .target(name: "Util", swiftSettings: swiftSettings),
         .testTarget(
             name: "PrivacyPassTests",
             dependencies: [
@@ -98,11 +100,15 @@ let package = Package(
         .target(
             name: "PIRServiceTesting",
             dependencies: [
-                "PrivacyPass",
+                "PrivacyPass", "Util",
                 .product(name: "HomomorphicEncryptionProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "HummingbirdTesting", package: "hummingbird"),
                 .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
             ],
+            swiftSettings: swiftSettings),
+        .testTarget(
+            name: "UtilTests",
+            dependencies: ["Util"],
             swiftSettings: swiftSettings),
     ])
 

--- a/Sources/PIRService/Application+build.swift
+++ b/Sources/PIRService/Application+build.swift
@@ -19,11 +19,13 @@ import Hummingbird
 import Logging
 import NIO
 import PrivateInformationRetrieval
+import Util
 
-struct AppContext: IdentifiedRequestContext, AuthenticatedRequestContext, RequestContext {
+struct AppContext: IdentifiedRequestContext, AuthenticatedRequestContext, PlatformRequestContext, RequestContext {
     var coreContext: CoreRequestContextStorage
     var userIdentifier: UserIdentifier
     var userTier: UserTier
+    var platform: Platform?
 
     // override upload size to 10MiB, the default 2MiB limit is too small for some evaluation keys.
     var maxUploadSize: Int {
@@ -32,6 +34,7 @@ struct AppContext: IdentifiedRequestContext, AuthenticatedRequestContext, Reques
 
     init(source: ApplicationRequestContextSource) {
         self.coreContext = .init(source: source)
+        self.platform = nil
         self.userIdentifier = UserIdentifier(identifier: "")
         self.userTier = .tier1
     }

--- a/Sources/PIRService/Controllers/Usecase.swift
+++ b/Sources/PIRService/Controllers/Usecase.swift
@@ -14,8 +14,14 @@
 
 import HomomorphicEncryptionProtobuf
 import PrivateInformationRetrievalProtobuf
+import Util
 
 protocol Usecase: Sendable {
+    /// Returns the configuration.
+    ///
+    /// Note: may use features that are not compatible with older platforms.
+    /// ``Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config/makeCompatible(with:)`` can be used to make the
+    /// configuration compatible with older platforms.
     func config() throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config
     func evaluationKeyConfig() throws -> Apple_SwiftHomomorphicEncryption_V1_EvaluationKeyConfig
     func process(

--- a/Sources/PIRService/Extensions/PirConfig+compatible.swift
+++ b/Sources/PIRService/Extensions/PirConfig+compatible.swift
@@ -1,0 +1,48 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PrivateInformationRetrievalProtobuf
+import Util
+
+extension Platform {
+    var supportsPirFixedShardConfig: Bool {
+        switch osType {
+        case .iOS:
+            osVersion >= .init(major: 18, minor: 2)
+        case .macOS:
+            osVersion >= .init(major: 15, minor: 2)
+        default:
+            fatalError("Unsupported platform \(self)")
+        }
+    }
+}
+
+public extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+    /// Makes the configuration compatible with the given platform.
+    /// - Parameter platform: Device platform.
+    mutating func makeCompatible(with platform: Platform) {
+        if !platform.supportsPirFixedShardConfig {
+            // Check for PIRFixedShardConfig, introduced in iOS 18.2
+            switch pirConfig.pirShardConfigs.shardConfigs {
+            case let .repeatedShardConfig(repeatedConfig):
+                pirConfig.shardConfigs = Array(
+                    repeating: repeatedConfig.shardConfig,
+                    count: Int(repeatedConfig.shardCount))
+                pirConfig.clearPirShardConfigs()
+            case .none:
+                break
+            }
+        }
+    }
+}

--- a/Sources/PIRService/Middlewares/ExtractPlatform.swift
+++ b/Sources/PIRService/Middlewares/ExtractPlatform.swift
@@ -1,0 +1,38 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import HTTPTypes
+import Hummingbird
+import Util
+
+protocol PlatformRequestContext: RequestContext {
+    var platform: Platform? { get set }
+}
+
+/// Middleware that extracts the platform from the 'User-Agent' header
+struct ExtractPlatformMiddleware<Context: PlatformRequestContext>: RouterMiddleware {
+    func handle(
+        _ input: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response) async throws -> Response
+    {
+        var context = context
+        guard let userAgent = input.headers[.userAgent] else {
+            throw HTTPError(.badRequest, message: "Missing 'User-Agent' header")
+        }
+        context.platform = Platform(userAgent: userAgent)
+        return try await next(input, context)
+    }
+}

--- a/Sources/PIRService/PIRService.docc/HTTPEndpoints.md
+++ b/Sources/PIRService/PIRService.docc/HTTPEndpoints.md
@@ -26,6 +26,7 @@ Request        | Value              | Description
 Method         | POST               | HTTP method.
 Path           | `/config`          | HTTP path.
 Header         | `Authorization`    | The value will contain a private access token.
+Header         | `User-Agent`       | Identifier for the user's OS type and version.
 Header         | `User-Identifier`  | Pseudorandom identifier tied to a user.
 Request Body   | `ConfigRequest`    | Serialized Protobuf message that list the use-cases that the system is interested in.
 Response       | `ConfigResponse`   | Serialized Protobuf message. The `ConfigResponse` contains the `configs` and `key_info` response fields.
@@ -43,6 +44,7 @@ Request        | Value              | Description
 Method         | POST               | HTTP method.
 Path           | `/key`             | HTTP path.
 Header         | `Authorization`    | The value will contain a private access token.
+Header         | `User-Agent`       | Identifier for the user's OS type and version.
 Header         | `User-Identifier`  | Pseudorandom identifier tied to a user.
 Body           | `EvaluationKeys`   | Serialized Protobuf message that contains evaluation key(s).
 
@@ -57,6 +59,7 @@ Request        | Value              | Description
 Method         | POST               | HTTP method.
 Path           | `/queries`         | HTTP path.
 Header         | `Authorization`    | The value will contain a private access token.
+Header         | `User-Agent`       | Identifier for the user's OS type and version.
 Header         | `User-Identifier`  | Pseudorandom identifier tied to a user.
 Request Body   | `Requests`         | Serialized Protobuf message.
 Response       | `Responses`        | Serialized Protobuf message.

--- a/Sources/PIRService/PIRService.docc/TestingInstructions.md
+++ b/Sources/PIRService/PIRService.docc/TestingInstructions.md
@@ -261,6 +261,11 @@ By default `PIRService` will start listening on the loopback interface, but you 
 make it listen on all network interfaces. The default port is `8080`, but it can be changed by using the `--port`
 option.
 
+### Features
+After introduction in iOS 18.0, `Live Caller ID Lookup` introduced further features.
+
+* `Fixed PIR Shard Config` (iOS 18.2). When all shard configurations are identical, `PIR Fixed Shard Config` allows for a more compact PIR config, saving bandwidth and client-side memory usage. To enable, set the `pirShardConfigs` field in the PIR config. iOS clients prior to iOS 18.2 will still require the `shardConfigs` field to be set. See [Reusing PIR Parameters]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval/reusingpirparameters) for how to process the database such that all shard configurations are identical.
+
 ## Writing the application extension
 
 > Important: Please see [Getting up-to-date calling and blocking information for your

--- a/Sources/PIRServiceTesting/PIRConfig+ShardConfig.swift
+++ b/Sources/PIRServiceTesting/PIRConfig+ShardConfig.swift
@@ -14,8 +14,10 @@
 
 import PrivateInformationRetrieval
 import PrivateInformationRetrievalProtobuf
+import Util
 
-extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig {
+public extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig {
+    /// The number of shards in the configuration.
     var shardCount: Int {
         if let pirShardConfigs = pirShardConfigs.shardConfigs {
             switch pirShardConfigs {
@@ -26,6 +28,9 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig {
         return shardConfigs.count
     }
 
+    /// Returns the shard configuration at an index.
+    /// - Parameter shardIndex: Shard index.
+    /// - Returns: The shard configuration.
     func shardConfig(shardIndex: Int) -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRShardConfig {
         if let pirShardConfigs = pirShardConfigs.shardConfigs {
             switch pirShardConfigs {
@@ -36,7 +41,10 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig {
         return shardConfigs[shardIndex]
     }
 
-    func shardindex(for keyword: KeywordValuePair.Keyword) throws -> Int {
+    /// Computes the shard index for a keyword.
+    /// - Parameter keyword: Keyword.
+    /// - Returns: The shard index for the keyword.
+    func shardIndex(for keyword: KeywordValuePair.Keyword) throws -> Int {
         if keywordPirParams.hasShardingFunction {
             switch keywordPirParams.shardingFunction.function {
             case .sha256:

--- a/Sources/Util/OperatingSystem.swift
+++ b/Sources/Util/OperatingSystem.swift
@@ -1,0 +1,96 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Type of an operation system.
+public struct OsType: Hashable, Sendable {
+    enum Internal {
+        case iOS
+        case macOS
+    }
+
+    /// iOS
+    public static let iOS: Self = .init(type: .iOS)
+
+    /// macOS
+    public static let macOS: Self = .init(type: .macOS)
+
+    let type: Internal
+}
+
+/// A version of an operating system.
+public struct OsVersion: Equatable, Hashable, Sendable {
+    /// Major version.
+    public let major: Int
+    /// Minor version.
+    public let minor: Int
+    /// Patch version.
+    public let patch: Int
+
+    /// Initializes an `OsVersion`.
+    /// - Parameters:
+    ///   - major: Major version.
+    ///   - minor: Minor version.
+    ///   - patch: Patch version.
+    public init(major: Int, minor: Int = 0, patch: Int = 0) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    /// Initializes an `OsVersion` from a string.
+    /// - Parameter string: Semantic version string. E.g., `MAJOR.MINOR.PATCH`
+    public init?(from string: String) {
+        let components = string.split(separator: ".")
+        guard components.count >= 1, components.count <= 3 else {
+            return nil
+        }
+        guard let major = Int(components[0]), major >= 0 else {
+            return nil
+        }
+        self.major = major
+
+        if components.count > 1 {
+            guard let minor = Int(components[1]), minor >= 0 else {
+                return nil
+            }
+            self.minor = minor
+        } else {
+            self.minor = 0
+        }
+
+        if components.count > 2 {
+            guard let patch = Int(components[2]), patch >= 0 else {
+                return nil
+            }
+            self.patch = patch
+        } else {
+            self.patch = 0
+        }
+    }
+}
+
+extension OsVersion: Comparable {
+    public static func < (lhs: OsVersion, rhs: OsVersion) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        }
+        if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        }
+        if lhs.patch != rhs.patch {
+            return lhs.patch < rhs.patch
+        }
+        return false
+    }
+}

--- a/Sources/Util/Platform.swift
+++ b/Sources/Util/Platform.swift
@@ -1,0 +1,88 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Description of a computing environment.
+public struct Platform: Equatable, Hashable, Sendable {
+    /// iOS 18.
+    public static let iOS18 = Platform(osType: .iOS, osVersion: .init(major: 18))
+    /// iOS 18.2.
+    public static let iOS18_2 = Platform(osType: .iOS, osVersion: .init(major: 18, minor: 2))
+
+    /// macOS 15.
+    public static let macOS15 = Platform(osType: .macOS, osVersion: .init(major: 15))
+    /// macOS 15.2.
+    public static let macOS15_2 = Platform(osType: .macOS, osVersion: .init(major: 15, minor: 2))
+
+    /// Operating system type.
+    public let osType: OsType
+    /// Operating system version.
+    public let osVersion: OsVersion
+
+    /// Initializes a `Platform`.
+    /// - Parameters:
+    ///   - osType: Operating system type.
+    ///   - osVersion: Operating system version.
+    public init(osType: OsType, osVersion: OsVersion) {
+        self.osVersion = osVersion
+        self.osType = osType
+    }
+
+    /// Initializes a platform from a `User-Agent` HTTP header.
+    /// - Parameter userAgent: `User-Agent` HTTP header.
+    public init?(userAgent: String) {
+        let iOSRegex: Regex = #/^.*iOS/(\d+)\.(\d+)\.?(\d)?.*/# // matches ... iOS/18.0 ...
+        let macOSRegex: Regex = #/^.*Macintosh; OS X (\d+)\.(\d+)\.?(\d)?.*/# // matches ... Macintosh; OS X 15.0.1 ...
+
+        // swiftlint:disable:next large_tuple
+        func parseOsVersion(from match: Regex<(Substring, Substring, Substring, Substring?)>.Match) -> OsVersion? {
+            guard let major = Int(match.output.1) else {
+                return nil
+            }
+            guard let minor = Int(match.output.2) else {
+                return nil
+            }
+            guard let patch = Int(match.output.3 ?? "0") else {
+                return nil
+            }
+            return OsVersion(major: major, minor: minor, patch: patch)
+        }
+
+        for (osType, regexExpression): (OsType, Regex) in [(.iOS, iOSRegex), (.macOS, macOSRegex)] {
+            // `wholeMatch` only throws on failable transformaton closures.
+            // swiftlint:disable:next force_try
+            if let match = try! regexExpression.wholeMatch(in: userAgent) {
+                if let osVersion = parseOsVersion(from: match) {
+                    self = .init(osType: osType, osVersion: osVersion)
+                    return
+                }
+                return nil
+            }
+        }
+        return nil
+    }
+}
+
+public extension Platform {
+    /// An example 'User-Agent' for a device with this platform.
+    var exampleUserAgent: String {
+        switch osType {
+        case .iOS:
+            "com.apple.ciphermld/1.0 iOS/\(osVersion.major).\(osVersion.minor) ..."
+        case .macOS:
+            "com.apple.ciphermld/1.2 (Macintosh; OS X \(osVersion.major).\(osVersion.minor); XXXXX) ..."
+        default:
+            fatalError("Unsupported OS type: \(osType)")
+        }
+    }
+}

--- a/Tests/PIRServiceTests/TestClientProtocol+Protobuf.swift
+++ b/Tests/PIRServiceTests/TestClientProtocol+Protobuf.swift
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import HTTPTypes
 import Hummingbird
 import HummingbirdTesting
 @testable import PIRService
 import PIRServiceTesting
 import SwiftProtobuf
+import Util
 import XCTest
 
 public extension TestClientProtocol {
@@ -26,13 +28,18 @@ public extension TestClientProtocol {
         userIdentifier: UserIdentifier,
         message: some Message,
         acceptCompression: Bool = false,
+        platform: Platform = .iOS18,
         testCallback: @escaping (TestResponse) async throws -> Return = { $0 }) async throws -> Return
     {
         let bodyBuffer = try ByteBuffer(data: message.serializedData())
-        var headers: HTTPFields = [.userIdentifier: userIdentifier.identifier]
+        var headers: HTTPFields = [
+            .userIdentifier: userIdentifier.identifier,
+            .userAgent: platform.exampleUserAgent,
+        ]
         if acceptCompression {
             headers[.acceptEncoding] = "gzip"
         }
+
         let response = try await executeRequest(uri: uri, method: .post, headers: headers, body: bodyBuffer)
         return try await testCallback(response)
     }

--- a/Tests/UtilTests/UtilTests.swift
+++ b/Tests/UtilTests/UtilTests.swift
@@ -1,0 +1,54 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Util
+import XCTest
+
+class UtilTests: XCTestCase {
+    func testOsVersion() throws {
+        let os18 = OsVersion(major: 18)
+        let os18_0_1 = OsVersion(major: 18, patch: 1)
+        let os18_1 = OsVersion(major: 18, minor: 1)
+        let os19 = OsVersion(major: 19, minor: 0)
+
+        XCTAssertLessThan(os18, os18_0_1)
+        XCTAssertLessThan(os18_0_1, os18_1)
+        XCTAssertLessThan(os18, os18_1)
+        XCTAssertLessThan(os18, os19)
+
+        XCTAssertEqual(OsVersion(from: "18"), os18)
+        XCTAssertEqual(OsVersion(from: "18.0"), os18)
+        XCTAssertEqual(OsVersion(from: "18.0.0"), os18)
+
+        XCTAssertEqual(OsVersion(from: "18.1"), os18_1)
+        XCTAssertEqual(OsVersion(from: "18.1.0"), os18_1)
+
+        XCTAssertNil(OsVersion(from: "abc"))
+        XCTAssertNil(OsVersion(from: "-1"))
+        XCTAssertNil(OsVersion(from: "1.2.3.4"))
+        XCTAssertNil(OsVersion(from: "1.2.3xyz"))
+    }
+
+    func testExampleUserAgent() throws {
+        func runTest(platform: Platform) {
+            let parsed = Platform(userAgent: platform.exampleUserAgent)
+            XCTAssertEqual(parsed, platform)
+        }
+
+        runTest(platform: .macOS15)
+        runTest(platform: .macOS15_2)
+        runTest(platform: .iOS18)
+        runTest(platform: .iOS18_2)
+    }
+}


### PR DESCRIPTION
As of iOS 18.2 (beta 2), when all shard configurations are identical, `PIR Fixed Shard Config` allows for a more compact PIR config, saving bandwidth and client-side memory usage. To enable, set the `pirShardConfigs` field in the PIR config. iOS clients prior to iOS 18.2 will still require the `shardConfigs` field to be set. See [Reusing PIR Parameters]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval/reusingpirparameters) for how to process the database such that all shard configurations are identical.
