### PR TITLE
Add support for reusing existingConfigId

### DIFF
--- a/Sources/PIRService/Controllers/Usecase.swift
+++ b/Sources/PIRService/Controllers/Usecase.swift
@@ -29,3 +29,15 @@ protocol Usecase: Sendable {
         evaluationKey: Apple_SwiftHomomorphicEncryption_Api_Shared_V1_EvaluationKey) async throws
         -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
 }
+
+extension Usecase {
+    func config(existingConfigId: [UInt8]) throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+        let config = try config()
+        if Array(config.configID) == existingConfigId {
+            return Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { apiConfig in
+                apiConfig.reuseExistingConfig = true
+            }
+        }
+        return config
+    }
+}

--- a/Sources/PIRService/PIRService.docc/HTTPEndpoints.md
+++ b/Sources/PIRService/PIRService.docc/HTTPEndpoints.md
@@ -29,7 +29,10 @@ Header         | `Authorization`    | The value will contain a private access to
 Header         | `User-Agent`       | Identifier for the user's OS type and version.
 Header         | `User-Identifier`  | Pseudorandom identifier tied to a user.
 Request Body   | `ConfigRequest`    | Serialized Protobuf message that list the use-cases that the system is interested in.
+                                      As of iOS 18.2, the client will set the `existing_config_ids` field.
 Response       | `ConfigResponse`   | Serialized Protobuf message. The `ConfigResponse` contains the `configs` and `key_info` response fields.
+                                      As of iOS 18.2, the message may set `reuse_existing_config: true` instead of the `pirConfig` field, reducing the message size.
+                                      This indicates the client should use the config with id specified in `existing_config_ids`.
 Response field | `configs`          | Map from use case names to the corresponding configuration.
 Response field | `key_info`         | List of `KeyStatus` objects.
 

--- a/Sources/PIRService/PIRService.docc/TestingInstructions.md
+++ b/Sources/PIRService/PIRService.docc/TestingInstructions.md
@@ -266,6 +266,8 @@ After introduction in iOS 18.0, `Live Caller ID Lookup` introduced further featu
 
 * `Fixed PIR Shard Config` (iOS 18.2). When all shard configurations are identical, `PIR Fixed Shard Config` allows for a more compact PIR config, saving bandwidth and client-side memory usage. To enable, set the `pirShardConfigs` field in the PIR config. iOS clients prior to iOS 18.2 will still require the `shardConfigs` field to be set. See [Reusing PIR Parameters]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval/reusingpirparameters) for how to process the database such that all shard configurations are identical.
 
+* `Reusing existing config id` (iOS 18.2). During the `config` request, if a client has a cached configuration, it will send the config id of that cached configuration. Then, if the configuration is unchanged, the server may respond with a config setting `reuseExistingConfig = true` and omit any other fields. This helps reduce the response size for the config fetch.
+
 ## Writing the application extension
 
 > Important: Please see [Getting up-to-date calling and blocking information for your


### PR DESCRIPTION
Add support for reusing  existingConfigId

As of iOS 18.2 (seed 2), during the `config` request, if a client has a cached configuration, it will send the config id of that cached configuration. Then, if the configuration is unchanged, the server may respond with a config setting `reuseExistingConfig = true` and omit any other fields. This helps reduce the response size for the config fetch.
