### PR TITLE
Throw error when incompatible platform is used

### DIFF
--- a/Sources/PIRService/Controllers/PIRServiceController.swift
+++ b/Sources/PIRService/Controllers/PIRServiceController.swift
@@ -82,7 +82,7 @@ struct PIRServiceController {
             if let usecase = requestedUsecases[usecaseName] {
                 var config = try usecase.config(existingConfigId: Array(configId))
                 if let platform = context.platform {
-                    config.makeCompatible(with: platform)
+                    try config.makeCompatible(with: platform)
                 }
                 configs[usecaseName] = config
             }

--- a/Sources/PIRService/PIRService.docc/TestingInstructions.md
+++ b/Sources/PIRService/PIRService.docc/TestingInstructions.md
@@ -268,6 +268,12 @@ After introduction in iOS 18.0, `Live Caller ID Lookup` introduced further featu
 
 * `Reusing existing config id` (iOS 18.2). During the `config` request, if a client has a cached configuration, it will send the config id of that cached configuration. Then, if the configuration is unchanged, the server may respond with a config setting `reuseExistingConfig = true` and omit any other fields. This helps reduce the response size for the config fetch.
 
+* `Sharding function configurability` (iOS 18.2). [Sharding
+  function](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase#Sharding-function)
+  can be configured. The `doubleMod` sharding function was designed specifically for the use case where multiple
+  requests are made with the same keyword, like in Live Caller ID Lookup, where we use the same phone number to look up
+  blocking information and Identity information. Note: this option is not backward compatible with older iOS versions.
+
 ## Writing the application extension
 
 > Important: Please see [Getting up-to-date calling and blocking information for your

--- a/Tests/PIRServiceTests/PIRServiceControllerTests.swift
+++ b/Tests/PIRServiceTests/PIRServiceControllerTests.swift
@@ -118,7 +118,7 @@ class PIRServiceControllerTests: XCTestCase {
                     { response in
                         XCTAssertEqual(response.status, .ok)
                         var expectedConfig = try exampleUsecase.config()
-                        expectedConfig.makeCompatible(with: platform)
+                        try expectedConfig.makeCompatible(with: platform)
                         let configResponse = try response
                             .message(as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.self)
                         XCTAssertEqual(configResponse.configs["test"], expectedConfig)

--- a/Tests/PIRServiceTests/PIRServiceTests.swift
+++ b/Tests/PIRServiceTests/PIRServiceTests.swift
@@ -141,13 +141,20 @@ class PIRServiceTests: XCTestCase {
         let shard0Config = config.pirConfig.shardConfig(shardIndex: 0)
         XCTAssertEqual(config.pirConfig.shardCount, 5)
 
-        config.makeCompatible(with: .iOS18)
+        try config.makeCompatible(with: .iOS18)
         XCTAssertEqual(config.pirConfig.shardConfigs.count, 5)
         XCTAssertEqual(config.pirConfig.shardConfigs, Array(repeating: shard0Config, count: 5))
         for shardIndex in 0..<5 {
             XCTAssertEqual(config.pirConfig.shardConfig(shardIndex: shardIndex), shard0Config)
         }
         XCTAssertEqual(config.pirConfig.shardCount, 5)
+
+        config.pirConfig.keywordPirParams.shardingFunction.function = .doubleMod(.with { doubleMod in
+            doubleMod.otherShardCount = 5
+        })
+
+        XCTAssertThrowsError(try config.makeCompatible(with: .iOS18))
+        XCTAssertNoThrow(try config.makeCompatible(with: .iOS18_2))
     }
 }
 


### PR DESCRIPTION
Configuring sharding function is not backwards compatible.