### PR TITLE
Fix CI for copyright header

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ env:
 jobs:
   swift-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -54,10 +54,23 @@ jobs:
       run: pip install pre-commit
     - name: Pre-commit checks
       # CI will commit to `main`
-      # swiftformat & swiftlint tested separately
+      # swiftformat, swiftlint and license checks tested separately
       run: >
-        SKIP=no-commit-to-branch,lockwood-swiftformat,swiftlint,check-doc-comments
+        SKIP=no-commit-to-branch,check-doc-comments,lockwood-swiftformat,swiftlint,insert-license
         pre-commit run --all-files
+  insert-license:
+          timeout-minutes: 1
+          runs-on: ubuntu-latest
+          steps:
+          - uses: actions/checkout@v4
+            with:
+              fetch-depth: 2
+          - name: Install pre-commit
+            run: pip install pre-commit
+          - name: List changed files
+            run: git diff --name-only HEAD~1
+          - name: Run license check
+            run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .benchmarkBaselines/
 .build/
+.index-build/
 .swiftpm
 .vscode/
 xcuserdata/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-merge-conflict


### PR DESCRIPTION
* Fix CI for copyright header (similar to https://github.com/apple/swift-homomorphic-encryption/pull/139)
* Pin CI to Ubuntu 22.04 (similar to https://github.com/apple/swift-homomorphic-encryption/pull/145)
* Update pre-commit deps