### PR TITLE
Add Xcode 16.1 dependency (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Building Live Caller ID Lookup Example requires:
 * 64-bit processor with little-endian memory representation
 * macOS or Linux operating system
 * [Swift](https://www.swift.org/) version 6.0 or later
+* Optionally, [XCode](https://developer.apple.com/xcode/) version 16.1 or later
 
 Additionally, developing Live Caller ID Lookup Example requires:
 * [Nick Lockwood SwiftFormat](https://github.com/nicklockwood/SwiftFormat)


### PR DESCRIPTION
As noted at https://github.com/apple/swift-homomorphic-encryption/tree/b73daaca802e16c9f6a31da76f26375c34896c15?tab=readme-ov-file#swift--xcode-versions, swift-homomorphic-encryption requires XCode >= 16.1

Related to https://github.com/apple/live-caller-id-lookup-example/issues/62