### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,24 +32,28 @@ env:
 jobs:
   swift-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift: [ "6.0" ]
-    name: swift ${{ matrix.swift }} tests
+        swift_version: ['6.0']
+        os_version: ['jammy']
+    container:
+      image: swift:${{ matrix.swift_version }}-${{ matrix.os_version }}
+    name: swift ${{ matrix.swift_version }} tests
     steps:
-    - uses: slashmo/install-swift@v0.4.0
-      with:
-        version: ${{ matrix.swift }}
-    - uses: actions/checkout@v4
+    - name: Swift version
+      run: swift --version
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Run tests
       run: swift test --configuration release --parallel
   pre-commit:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Pre-commit checks
@@ -59,23 +63,25 @@ jobs:
         SKIP=no-commit-to-branch,check-doc-comments,lockwood-swiftformat,swiftlint,insert-license
         pre-commit run --all-files
   insert-license:
-          timeout-minutes: 1
-          runs-on: ubuntu-latest
-          steps:
-          - uses: actions/checkout@v4
-            with:
-              fetch-depth: 2
-          - name: Install pre-commit
-            run: pip install pre-commit
-          - name: List changed files
-            run: git diff --name-only HEAD~1
-          - name: Run license check
-            run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Install pre-commit
+      run: pip install pre-commit
+    - name: List changed files
+      run: git diff --name-only HEAD~1
+    - name: Run license check
+      run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache SwiftLint
       id: cache-swiftlint
       uses: actions/cache@v4
@@ -92,7 +98,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache SwiftFormat
       id: cache-swiftformat
       uses: actions/cache@v4


### PR DESCRIPTION
`slashmo` is using a deprecated version of `actions/cache: v3.2.3`. So we remove the dependency on `slashmo`.