### PR TITLE
Adopt GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,114 +1,96 @@
-# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: CI
 permissions:
   contents: read
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main", "release/**"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "release/**"]
     types: [opened, reopened, synchronize]
 # Pushing changes to PR stops currently-running CI
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
-  SWIFTLINT_VERSION: 0.57.0
-  SWIFTFORMAT_VERSION: 0.54.6
+  SWIFTLINT_VERSION: 0.58.2
+  SWIFTFORMAT_VERSION: 0.55.5
 jobs:
-  swift-tests:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        swift_version: ['6.0']
-        os_version: ['jammy']
-    container:
-      image: swift:${{ matrix.swift_version }}-${{ matrix.os_version }}
-    name: swift ${{ matrix.swift_version }} tests
-    steps:
-    - name: Swift version
-      run: swift --version
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Run tests
-      run: swift test --configuration release --parallel
+  soundness:
+    name: soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    with:
+      # https://github.com/swiftlang/swift-package-manager/issues/8103
+      api_breakage_check_enabled: false
+      format_check_enabled: false
+  tests:
+    name: swifttests
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      # https://github.com/apple/swift-distributed-tracing/issues/165
+      enable_windows_checks: false
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
   pre-commit:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install pre-commit
-      run: pip install pre-commit
-    - name: Pre-commit checks
-      # CI will commit to `main`
-      # swiftformat, swiftlint and license checks tested separately
-      run: >
-        SKIP=no-commit-to-branch,check-doc-comments,lockwood-swiftformat,swiftlint,insert-license
-        pre-commit run --all-files
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Pre-commit checks
+        # CI will commit to `main`
+        # swiftformat, swiftlint and license checks tested separately
+        run: >
+          SKIP=no-commit-to-branch,check-doc-comments,lockwood-swiftformat,swiftlint,insert-license
+          pre-commit run --all-files
   insert-license:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-    - name: Install pre-commit
-      run: pip install pre-commit
-    - name: List changed files
-      run: git diff --name-only HEAD~1
-    - name: Run license check
-      run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: List changed files
+        run: git diff --name-only HEAD~1
+      - name: Run license check
+        run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Cache SwiftLint
-      id: cache-swiftlint
-      uses: actions/cache@v4
-      with:
-        path: /tmp/swiftlint/SwiftLint/.build/release/swiftlint
-        key: ${{ runner.os }}-swiftlint-${{ env.SWIFTLINT_VERSION }}
-    - name: Install SwiftLint
-      if: steps.cache-swiftlint.outputs.cache-hit != 'true'
-      run: |
-        ci/install-swiftlint.sh
-    - name: Run SwiftLint
-      run: /tmp/swiftlint/SwiftLint/.build/release/swiftlint lint --strict .
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Cache SwiftLint
+        id: cache-swiftlint
+        uses: actions/cache@v4
+        with:
+          path: /tmp/swiftlint/SwiftLint/.build/release/swiftlint
+          key: ${{ runner.os }}-swiftlint-${{ env.SWIFTLINT_VERSION }}
+      - name: Install SwiftLint
+        if: steps.cache-swiftlint.outputs.cache-hit != 'true'
+        run: |
+          ci/install-swiftlint.sh
+      - name: Run SwiftLint
+        run: /tmp/swiftlint/SwiftLint/.build/release/swiftlint lint --strict .
   lockwood-swiftformat:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Cache SwiftFormat
-      id: cache-swiftformat
-      uses: actions/cache@v4
-      with:
-        path: /tmp/swiftformat/SwiftFormat/.build/release/swiftformat
-        key: ${{ runner.os }}-swiftformat-${{ env.SWIFTFORMAT_VERSION }}
-    - name: Install Lockwood SwiftFormat
-      if: steps.cache-swiftformat.outputs.cache-hit != 'true'
-      run: |
-        ci/install-lockwood-swiftformat.sh
-    - name: Run SwiftFormat
-      run: /tmp/swiftformat/SwiftFormat/.build/release/swiftformat --strict .
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Cache SwiftFormat
+        id: cache-swiftformat
+        uses: actions/cache@v4
+        with:
+          path: /tmp/swiftformat/SwiftFormat/.build/release/swiftformat
+          key: ${{ runner.os }}-swiftformat-${{ env.SWIFTFORMAT_VERSION }}
+      - name: Install Lockwood SwiftFormat
+        if: steps.cache-swiftformat.outputs.cache-hit != 'true'
+        run: |
+          ci/install-lockwood-swiftformat.sh
+      - name: Run SwiftFormat
+        run: /tmp/swiftformat/SwiftFormat/.build/release/swiftformat --strict .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
       # https://github.com/apple/swift-distributed-tracing/issues/165
       enable_windows_checks: false
       linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
+      linux_build_command: "swift test --configuration release"
   pre-commit:
     timeout-minutes: 1
     runs-on: ubuntu-latest
@@ -68,14 +69,14 @@ jobs:
         id: cache-swiftlint
         uses: actions/cache@v4
         with:
-          path: /tmp/swiftlint/SwiftLint/.build/release/swiftlint
+          path: /tmp/swiftlint/SwiftLint/.build/debug/swiftlint
           key: ${{ runner.os }}-swiftlint-${{ env.SWIFTLINT_VERSION }}
       - name: Install SwiftLint
         if: steps.cache-swiftlint.outputs.cache-hit != 'true'
         run: |
           ci/install-swiftlint.sh
       - name: Run SwiftLint
-        run: /tmp/swiftlint/SwiftLint/.build/release/swiftlint lint --strict .
+        run: /tmp/swiftlint/SwiftLint/.build/debug/swiftlint lint --strict .
   lockwood-swiftformat:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.license_header_template
+++ b/.license_header_template
@@ -1,0 +1,13 @@
+@@ Copyright YEARS Apple Inc. and the Swift Homomorphic Encryption project authors
+@@
+@@ Licensed under the Apache License, Version 2.0 (the "License");
+@@ you may not use this file except in compliance with the License.
+@@ You may obtain a copy of the License at
+@@
+@@     http://www.apache.org/licenses/LICENSE-2.0
+@@
+@@ Unless required by applicable law or agreed to in writing, software
+@@ distributed under the License is distributed on an "AS IS" BASIS,
+@@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@@ See the License for the specific language governing permissions and
+@@ limitations under the License.

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,8 @@
+**/.swiftformat
+*.pb.swift
+*.png
+.gitignore
+.swiftformat
+Package.resolved
+Package.swift
+Snippets/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,66 +1,54 @@
-# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: check-case-conflict
-    -   id: check-merge-conflict
-    -   id: check-symlinks
-    -   id: fix-byte-order-marker
-    -   id: check-toml
-    -   id: check-yaml
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: fix-byte-order-marker
+      - id: check-toml
+      - id: check-yaml
         args: [--allow-multiple-documents]
-    -   id: end-of-file-fixer
-    -   id: mixed-line-ending
-    -   id: no-commit-to-branch
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
         args: [--branch, main]
-    -   id: trailing-whitespace
--   repo: https://github.com/Lucas-C/pre-commit-hooks
+      - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
-    -   id: insert-license
+      - id: insert-license
         name: insert-license
         'types_or': [c, swift, proto]
         args:
-           - --license-filepath
-           - copyright-header.txt
-           - --comment-style
-           - //
-           - --allow-past-years
-           - --use-current-year
-           - --detect-license-in-X-top-lines=10
-    -   id: insert-license
-        name: insert-license-yaml
-        'types_or': [yaml]
+          - --license-filepath
+          - copyright-header.txt
+          - --comment-style
+          - //
+          - --allow-past-years
+          - --use-current-year
+          - --detect-license-in-X-top-lines=10
+      - id: insert-license
+        name: insert-license-sh
+        types_or: [shell]
         args:
-           - --license-filepath
-           - copyright-header.txt
-           - --allow-past-years
-           - --use-current-year
--   repo: local
+          - --license-filepath
+          - copyright-header.txt
+          - --comment-style
+          - "##"
+          - --allow-past-years
+          - --use-current-year
+  - repo: local
     hooks:
-    # Note, this is https://github.com/nicklockwood/SwiftFormat, not
-    # https://github.com/apple/swift-format
-    -   id: lockwood-swiftformat
+      # Note, this is https://github.com/nicklockwood/SwiftFormat, not
+      # https://github.com/apple/swift-format
+      - id: lockwood-swiftformat
         name: lockwood-swiftformat
         entry: swiftformat
         language: system
         types: [swift]
-    # https://github.com/realm/SwiftLint
-    -   id: swiftlint
+      # https://github.com/realm/SwiftLint
+      - id: swiftlint
         name: swiftlint
         entry: swiftlint lint --strict
         language: system

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,17 +1,3 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 version: 1
 builder:
   configs:

--- a/.swiftformat
+++ b/.swiftformat
@@ -7,5 +7,4 @@
 --nospaceoperators ..<, ...
 --ranges no-space
 --self init-only
---swiftversion 5.8
---asynccapturing XCTAssertAsyncThrowsError
+--swiftversion 6.0

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,41 +1,21 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 disabled_rules:
   - cyclomatic_complexity
   - file_length
   - function_body_length
   - identifier_name
-  - opening_brace # conflicts with swiftformat
+  - opening_brace  # conflicts with swiftformat
   - todo
-  - trailing_comma # conflicts with swiftformat
+  - trailing_comma  # conflicts with swiftformat
   - type_body_length
-  - vertical_parameter_alignment_on_call # conflicts with swiftformat
-  - file_header # pre-commit deals with license header
-  - raw_value_for_camel_cased_codable_enum # conflicts with swiftformat
-
-excluded:
-  - "**/*pb.swift"
-  - "**/.build/"
-
+  - vertical_parameter_alignment_on_call  # conflicts with swiftformat
+  - file_header  # pre-commit deals with license header
+  - raw_value_for_camel_cased_codable_enum  # conflicts with swiftformat
+excluded: ['**/*pb.swift', '**/.build/']
 line_length:
   warning: 120
   ignores_urls: true
-
 closure_body_length:
   warning: 40
-
 opt_in_rules:
   - accessibility_label_for_image
   - accessibility_trait_for_button
@@ -139,7 +119,6 @@ opt_in_rules:
   - weak_delegate
   - xct_specific_matcher
   - yoda_condition
-
 # Disabled rules
 # Deprecated or requires running analyzer
 # - anyobject_protocol

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: default
+rules:
+  line-length: false
+  document-start: false
+  truthy:
+    check-keys: false  # Otherwise we get a false positive on GitHub action's `on` key
+ignore: [.build, .index-build]

--- a/Sources/PIRService/Controllers/Usecase.swift
+++ b/Sources/PIRService/Controllers/Usecase.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ protocol Usecase: Sendable {
     /// Returns the configuration.
     ///
     /// Note: may use features that are not compatible with older platforms.
-    /// ``Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config/makeCompatible(with:)`` can be used to make the
-    /// configuration compatible with older platforms.
+    /// ``PrivateInformationRetrievalProtobuf/Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config/makeCompatible(with:)``
+    /// can be used to make the configuration compatible with older platforms.
     func config() throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config
     func evaluationKeyConfig() throws -> Apple_SwiftHomomorphicEncryption_V1_EvaluationKeyConfig
     func process(

--- a/Sources/PIRService/Controllers/UserAuthenticator.swift
+++ b/Sources/PIRService/Controllers/UserAuthenticator.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-actor UserAuthenticator: UserTokenAuthenticator, Sendable {
+actor UserAuthenticator: UserTokenAuthenticator {
     var allowList: [String: UserTier]
 
     init() {

--- a/Sources/PIRService/PIRService.docc/Authentication.md
+++ b/Sources/PIRService/PIRService.docc/Authentication.md
@@ -54,7 +54,7 @@ the issuer name. Redemption context and origin info fields will be left unset.
 
 The token request includes the User Token in the `Authorization` HTTP header.
 
-## See also
+### See also
 
 - [The Privacy Pass Architecture](https://www.rfc-editor.org/rfc/rfc9576)
 - [Privacy Pass Issuance Protocols](https://www.rfc-editor.org/rfc/rfc9578)

--- a/Sources/PIRService/PIRService.docc/CommonErrors.md
+++ b/Sources/PIRService/PIRService.docc/CommonErrors.md
@@ -8,13 +8,13 @@ While using the example service or when developing your own service, you will mo
 that will be listed below. This page gives more details about the errors, like why they happen, what they mean, and how
 to work around them.
 
-## How to look for errors
+### How to look for errors
 
 You can use the Console app to see on-device logs. Search for error messages from the `com.apple.cipherml` subsystem.
 
-## Common problems
+### Common problems
 
-### The request timed out
+#### The request timed out
 
 **Error example**:
 
@@ -33,7 +33,7 @@ This problem has multiple potential causes with multiple workarounds.
 2. Double-check that the device is on the same network as your MacBook.
 3. Change from using mDNS to a IP address directly.
 
-### Failed to fetch token
+#### Failed to fetch token
 **Error example**:
 
 ```
@@ -53,7 +53,7 @@ The `issuerRequestUri` field in `service-config.json` should also contain `/issu
 `http://MacBook-Pro.local:8080/issue`. Also make sure that the user token in the extension matches one in the
 `service-config.json`.
 
-### Missing configuration
+#### Missing configuration
 
 **Error example**:
 
@@ -75,7 +75,7 @@ Double-check that the service has usecases configured the way the device expects
 
 where `<bundleIdentifier>` is replaced with bundle identifier of your Live Caller ID Lookup extension.
 
-### No token key found with key id
+#### No token key found with key id
 
 **Error example**:
 
@@ -105,7 +105,7 @@ therefore making the cached tokens invalid.
 Once the device runs out of cached tokens, it will fetch new ones. One way to speed up the process is to call
 [refreshPIRParameters(forExtensionWithIdentifier:)](https://developer.apple.com/documentation/sms_and_call_reporting/livecalleridlookupmanager/4418043-refreshpirparameters).
 
-### Evaluation key not found
+#### Evaluation key not found
 
 **Error example**:
 

--- a/Sources/PIRService/PIRService.docc/Onboarding.md
+++ b/Sources/PIRService/PIRService.docc/Onboarding.md
@@ -11,18 +11,18 @@ your chosen oblivious HTTP gateway.
 
 ![Oblivious HTTP flow diagram](oblivious-http.png)
 
-## How to test without private relay
+### How to test without private relay
 
 The system does not use private relay, when the application is installed directly from Xcode. This allows the
 application & the service deployment to be tested before filling out the onboarding form and setting up Oblivious HTTP
 relay.
 
 
-## Requirements
+### Requirements
 
 Before filling out the form, there are a few requirements you have to satisfy to ensure smooth operations.
 
-### OHTTP gateway
+#### OHTTP gateway
 
 Apple's OHTTP relay expects your chosen OHTTP gateway to support HTTP/2. You can verify it by running.
 ```
@@ -30,7 +30,7 @@ openssl s_client -alpn h2 -connect $(OHTTP_GATEWAY_FQDN):443 </dev/null
 ```
 In the output check if the SSL session was established or not.
 
-### URLs
+#### URLs
 Please provide the URLs as you would put them into the
 [LiveCallerIDLookupExtensionContext](https://developer.apple.com/documentation/identitylookup/livecalleridlookupextensioncontext).
 
@@ -49,7 +49,7 @@ Bad example:
 http://example.net:8080/lookup - No HTTPS, non standard port, path instead of subdomain
 ```
 
-### HTTP Bearer Token / UserToken
+#### HTTP Bearer Token / UserToken
 The `userToken` field is a of type `Data` and the system sets the "Authorization" header like this:
 ```swift
 request.setValue("Bearer \(userToken.base64EncodedString())", forHTTPHeaderField: "Authorization")
@@ -57,7 +57,7 @@ request.setValue("Bearer \(userToken.base64EncodedString())", forHTTPHeaderField
 This implies that when filling out the form, you must enter a valid base64 encoding.
 > Warning: For example JSON Web Tokens are not valid base64 encodings and are therefore unsupported.
 
-### Checklist
+#### Checklist
 
 1. You must know the bundle identifier of your Live Caller ID Lookup extension.
 2. You need to provide expected request and response size and per continent traffic estimates that include:
@@ -79,7 +79,7 @@ This implies that when filling out the form, you must enter a valid base64 encod
 11. You must ensure that your deployment (including Oblivious HTTP gateway & PIR service) is running so that we can
     perform the validation test.
 
-## Onboarding form
+### Onboarding form
 
 The onboarding form should be filled out when you have a working service, but before you start distributing your
 application with the Live Caller ID Lookup extension.

--- a/Sources/PIRService/PIRService.docc/TestingInstructions.md
+++ b/Sources/PIRService/PIRService.docc/TestingInstructions.md
@@ -13,7 +13,7 @@ the feature. The general outline of the steps involved is as follows:
 * Running the service.
 * Writing the application extension.
 
-## Getting the tools on your path
+### Getting the tools on your path
 
 These testing steps assume that you have the following binaries available on your `$PATH`.
 The binaries are:
@@ -29,14 +29,14 @@ export PATH="$HOME/.swiftpm/bin:$PATH"
 Make sure to reload it (`source ~/.zshrc`) or by restarting your terminal emulator. Then we are going to use the
 `experimental-install` feature of Swift Package Manager.
 
-### ConstructDatabase
+#### ConstructDatabase
 
 Change directory to a checkout of this repository and run the following command.
 ```sh
 swift package experimental-install -c release --product ConstructDatabase
 ```
 
-### PIRProcessDatabase
+#### PIRProcessDatabase
 
 This tool comes from the [main repository](https://github.com/apple/swift-homomorphic-encryption) of Swift Homomorphic
 Encryption. Change directory to a checkout of the main repository and run the following command.
@@ -45,14 +45,14 @@ Encryption. Change directory to a checkout of the main repository and run the fo
 swift package experimental-install -c release --product PIRProcessDatabase
 ```
 
-### PIRService
+#### PIRService
 
 Change directory to a checkout of this repository and run the following command.
 ```sh
 swift package experimental-install -c release --product PIRService
 ```
 
-## Preparing the dataset
+### Preparing the dataset
 
 > Seealso: <doc:DataFormat>
 
@@ -98,7 +98,7 @@ This file is a [text format representation](https://protobuf.dev/reference/proto
 The schema for the message can be found at `Sources/ConstructDatabase/protobuf/InputIdentities.proto`. As you can see,
 we have set up 3 identities.
 
-### Adding icons
+#### Adding icons
 While `input.txtpb` contains almost all the fields that are needed, it is missing icons. Icons are somewhat hard to
 represent in a textual format so `ConstructDatabase` provides a way to overcome that limitation. To add icons for the
 identities create a new folder:
@@ -124,7 +124,7 @@ $ ls icons
 It is not necessary to provide icons for all identities. When `ConstuctDatabase` is parsing the input identities file,
 it will search for the icon in the icons directory and attaches it if it is found.
 
-## Constructing the two databases
+### Constructing the two databases
 Once we have prepared our input in the `input.txtpb` file and the `icons` folder. It is time to call:
 ```sh
 ConstructDatabase --icon-directory icons input.txtpb block.binpb identity.binpb
@@ -135,7 +135,7 @@ expected for Live Caller ID Lookup. Both of these are in binary protobuf format,
 [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
 utility.
 
-## Processing the datasets
+### Processing the datasets
 
 Before setting up a server to host these two datasets we need to process them a bit, so the online PIR queries can be
 done faster. For this we will use the
@@ -198,7 +198,7 @@ This will create the following files:
 > Important: The blocking dataset is has very small entries and the identity dataset has larger entries. So it makes
 > sense to use different parameters for them.
 
-## Running the service
+### Running the service
 
 Copy the following to a file called `service-config.json`.
 
@@ -256,7 +256,7 @@ By default `PIRService` will start listening on the loopback interface, but you 
 make it listen on all network interfaces. The default port is `8080`, but it can be changed by using the `--port`
 option.
 
-### Features
+#### Features
 After introduction in iOS 18.0, `Live Caller ID Lookup` introduced further features.
 
 * `Fixed PIR Shard Config` (iOS 18.2). When all shard configurations are identical, `PIR Fixed Shard Config` allows for a more compact PIR config, saving bandwidth and client-side memory usage. To enable, set the `pirShardConfigs` field in the PIR config. iOS clients prior to iOS 18.2 will still require the `shardConfigs` field to be set. See [Reusing PIR Parameters]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval/reusingpirparameters) for how to process the database such that all shard configurations are identical.
@@ -269,7 +269,7 @@ After introduction in iOS 18.0, `Live Caller ID Lookup` introduced further featu
   requests are made with the same keyword, like in Live Caller ID Lookup, where we use the same phone number to look up
   blocking information and Identity information. Note: this option is not backward compatible with older iOS versions.
 
-## Writing the application extension
+### Writing the application extension
 
 > Important: Please see [Getting up-to-date calling and blocking information for your
 > app](https://developer.apple.com/documentation/sms_and_call_reporting/getting_up-to-date_calling_and_blocking_information_for_your_app)
@@ -297,7 +297,7 @@ var context: LiveCallerIDLookupExtensionContext { get {
 }}
 ```
 
-### Running locally
+#### Running locally
 
 When running things locally on your Mac, and your testing device is on the same network, then you can use mDNS to let
 the device find your Mac. Let's assume that your Mac's hostname is `Tims-MacBook-Pro.local`.

--- a/Sources/PrivacyPass/PublicKey+request.swift
+++ b/Sources/PrivacyPass/PublicKey+request.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,8 @@ public extension PublicKey {
 
 /// Prepared token request.
 ///
-/// This can be obtained from ``PublicKey/request(challenge:)``. This will contain the ``TokenRequest`` object and after
+/// This can be obtained from ``PublicKey/request(challenge:)-3cdrp`` or
+/// ``PublicKey/request(challenge:)-1kbv0``. This will contain the ``TokenRequest`` object and after
 /// obtaining a ``TokenResponse`` can be finalized into a ``Token``.
 public struct PreparedRequest {
     let publicKey: PublicKey

--- a/ci/install-lockwood-swiftformat.sh
+++ b/ci/install-lockwood-swiftformat.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
+## Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -e
 
 echo "installing Lockwood swiftformat"
 DIR=$PWD
 mkdir -p /tmp/swiftformat
 cd /tmp/swiftformat || exit 1
-git clone --depth 1 --branch $SWIFTFORMAT_VERSION https://github.com/nicklockwood/SwiftFormat
+git clone --depth 1 --branch "$SWIFTFORMAT_VERSION" https://github.com/nicklockwood/SwiftFormat
 cd SwiftFormat || exit 1
 swift build -c release
 export PATH=$PATH:$PWD/.build/release/

--- a/ci/install-swiftlint.sh
+++ b/ci/install-swiftlint.sh
@@ -21,7 +21,8 @@ mkdir -p /tmp/swiftlint
 cd /tmp/swiftlint || exit 1
 git clone --depth 1 --branch "$SWIFTLINT_VERSION" https://github.com/realm/SwiftLint
 cd SwiftLint || exit
-swift build -c release
-export PATH=$PATH:$PWD/.build/release/
+swift build -c debug
+# Building in release mode is slow
+export PATH=$PATH:$PWD/.build/debug/
 cd "$DIR" || exit 1
 which swiftlint

--- a/ci/install-swiftlint.sh
+++ b/ci/install-swiftlint.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
+## Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -e
 
 echo "installing swiftlint"
 DIR=$PWD
 mkdir -p /tmp/swiftlint
 cd /tmp/swiftlint || exit 1
-git clone --depth 1 --branch $SWIFTLINT_VERSION https://github.com/realm/SwiftLint
+git clone --depth 1 --branch "$SWIFTLINT_VERSION" https://github.com/realm/SwiftLint
 cd SwiftLint || exit
 swift build -c release
 export PATH=$PATH:$PWD/.build/release/


### PR DESCRIPTION
Adopt [github-workflows](https://github.com/swiftlang/github-workflows/tree/main), including:
* updating swiftformat / swiftlint versions
* running CI on release branches
* remove copyright header from yaml files (since github-workflows doesn't require it)
* switch SwiftLint CI to debug mode, since building in release mode is slow