### PR TITLE
Fix token assigned to multiple tiers error message

### DIFF
--- a/Sources/PIRService/ReloadService.swift
+++ b/Sources/PIRService/ReloadService.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ actor ReloadService: Service {
                    existingTier != tier
                 {
                     logger.warning("""
-                        User token '\token' is assigned to multiple tiers '\(existingTier)' \
+                        User token '\(token)' is assigned to multiple tiers '\(existingTier)' \
                         and '\(tier)', using the latter.
                         """)
                 }


### PR DESCRIPTION
The message was: "User token '	oken' is assigned to multiple tiers 'tier1' and 'tier2', using the latter."
This is because of missing parentheses.